### PR TITLE
aiurdemux: Use GST_TAG_LOCATION tag for USER_DATA_LOCATION

### DIFF
--- a/plugins/aiurdemux/aiurdemux.c
+++ b/plugins/aiurdemux/aiurdemux.c
@@ -195,7 +195,7 @@ static AiurDemuxTagEntry g_user_data_entry[] = {
       "Track Number : %s\n"},
   {USER_DATA_TOTALTRACKNUMBER, USER_DATA_FORMAT_UTF8, GST_TAG_TRACK_COUNT,
       "Track Count : %s\n"},
-  {USER_DATA_LOCATION, USER_DATA_FORMAT_UTF8, -1,
+  {USER_DATA_LOCATION, USER_DATA_FORMAT_UTF8, GST_TAG_LOCATION,
       "Location : %s\n"},
   {USER_DATA_KEYWORDS, USER_DATA_FORMAT_UTF8, GST_TAG_KEYWORDS,
       "Keywords : %s\n"},


### PR DESCRIPTION
-1 is not a string and GST_TAG_LOCATION is defined in gst/gsttaglist.h as "location", this fixes build error with clang

plugins/aiurdemux/aiurdemux.c:198:47: error: incompatible integer to pointer conversion initializing 'const gchar *' (aka 'const char *') with an expression of type 'int' [-Wint-conversion]
|   {USER_DATA_LOCATION, USER_DATA_FORMAT_UTF8, -1,
|                                               ^~

Signed-off-by: Khem Raj <raj.khem@gmail.com>